### PR TITLE
Allow to set a domain for cookies

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -1175,6 +1175,9 @@ class Resource(ModelImporter):
 
         if Setting().get(SettingKey.SECURE_COOKIE):
             cookie['girderToken']['secure'] = True
+        domain = Setting().get(SettingKey.COOKIE_DOMAIN)
+        if domain:
+            cookie['girderToken']['domain'] = domain
 
         return token
 

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -167,6 +167,7 @@ class SettingKey(object):
     PRIVACY_NOTICE = 'core.privacy_notice'
     CONTACT_EMAIL_ADDRESS = 'core.contact_email_address'
     COOKIE_LIFETIME = 'core.cookie_lifetime'
+    COOKIE_DOMAIN = 'core.cookie_domain'
     CORS_ALLOW_HEADERS = 'core.cors.allow_headers'
     CORS_ALLOW_METHODS = 'core.cors.allow_methods'
     CORS_ALLOW_ORIGIN = 'core.cors.allow_origin'
@@ -209,6 +210,7 @@ class SettingDefault(object):
         SettingKey.CONTACT_EMAIL_ADDRESS: 'kitware@kitware.com',
         SettingKey.PRIVACY_NOTICE: 'https://www.kitware.com/privacy',
         SettingKey.COOKIE_LIFETIME: 180,
+        SettingKey.COOKIE_DOMAIN: None,
         # These headers are necessary to allow the web server to work with just
         # changes to the CORS origin
         SettingKey.CORS_ALLOW_HEADERS:

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -212,6 +212,11 @@ class Setting(Model):
         return config.getConfig()['server']['mode'] == 'production'
 
     @staticmethod
+    @setting_utilities.validator(SettingKey.COOKIE_DOMAIN)
+    def validateCookieDomain(doc):
+        pass
+
+    @staticmethod
     @setting_utilities.validator(SettingKey.PLUGINS_ENABLED)
     def validateCorePluginsEnabled(doc):
         """


### PR DESCRIPTION
Image with this PR included is available @ Docker Hub as `wholetale/girder:cookie`

Don't forget to set the domain in `setup_girder.py`:

```diff
diff --git a/setup_girder.py b/setup_girder.py
index 385baa0..3d4e235 100755
--- a/setup_girder.py
+++ b/setup_girder.py
@@ -107,6 +107,7 @@ settings = [
             "X-Forwarded-Host, Remote-Addr, Cache-Control"
         ),
     },
+    {"key": "core.cookie_domain", "value": ".local.wholetale.org"},
     {"key": "worker.api_url", "value": "http://girder:8080/api/v1"},
     {"key": "worker.broker", "value": "redis://redis/"},
     {"key": "worker.backend", "value": "redis://redis/"},
```