### PR TITLE
Add default heartbeat config to  image

### DIFF
--- a/girder.local.cfg.dev
+++ b/girder.local.cfg.dev
@@ -16,3 +16,4 @@ api_root = "/api/v1"
 static_root = "/static"
 api_static_root = "../static"
 cherrypy_server = True
+heartbeat = 300


### PR DESCRIPTION
Since the girder config is built into the image, add default heartbeat config for production.