### PR TITLE
Pass progressCurrent to jobs.job.update event

### DIFF
--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -380,6 +380,7 @@ class Job(AccessControlledModel):
                 'log': log,
                 'overwrite': overwrite,
                 'status': status,
+                'progressCurrent': progressCurrent,
                 'progressTotal': progressTotal,
                 'progressMessage': progressMessage,
                 'otherFields': otherFields


### PR DESCRIPTION
No idea why it was omitted in the first place, but I need it...