### PR TITLE
Pin gcp version to 3.0.4 for now

### DIFF
--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -74,9 +74,9 @@ RUN set -ex \
 	&& ldconfig
 
 # install GCP client
-ENV GCP_URL=https://downloads.globus.org/globus-connect-personal/linux/stable/globusconnectpersonal-latest.tgz
-RUN wget -qO- $GCP_URL | tar xz -C /opt && \
-  mv /opt/globusconnectpersonal-* /opt/globusconnectpersonal
+# ENV GCP_URL=https://downloads.globus.org/globus-connect-personal/linux/stable/globusconnectpersonal-latest.tgz
+ENV GCP_URL=https://github.com/whole-tale/globus_handler/releases/download/gcp-3.0.4/globusconnectpersonal-3.0.4.tar.gz
+RUN wget -qO- $GCP_URL | tar xz -C /opt 
 
 RUN groupadd -r girder \
   && useradd --no-log-init -s /bin/bash -p $(openssl rand -base64 32) -m -r -g girder girder \


### PR DESCRIPTION
Fixes https://github.com/whole-tale/globus_handler/issues/1 :

**Problem**:
Apparently globusconnectpersonal v3.1.x changed the setup process, breaking support for the `-dir` flag.  This PR pins the gcp version to 3.0.4, which works.

**To Test**:
* Build and start Girder image using this PR or use `craigwillis/girder:gcp-3.0.4`
* Create a new Tale
* Register doi:10.18126/M2301J and add tale
* Start tale, open console
* `cd ../data/Twin-mediated...` and `cat globus_metadata.json`
* You should see the file contents instead of the error in https://github.com/whole-tale/globus_handler/issues/1

For grins:
```
$ docker exec --user girder -it <girder> bash

$ /opt/globusconnectpersonal/globusconnectpersonal -version
Globus Connect Personal 3.0.4

$ tail /home/girder/.girder/logs/error.log

[2022-02-15 15:36:46,565] INFO: Output from command ('/opt/globusconnectpersonal/globusconnectpersonal', '-dir', '/home/girder/.WholeTale/0baa7c04-1ff6-4cf5-82b3-00dd47e828d9', '-setup', '6a2e2ba2-f5af-406e-a37d-547479f879e4'): b"Could not read the directory '/home/girder/.WholeTale/0baa7c04-1ff6-4cf5-82b3-00dd47e828d9' with configuration files.\nCreating the directory... Done\nConfiguration directory: /home/girder/.WholeTale/0baa7c04-1ff6-4cf5-82b3-00dd47e828d9/lta\nContacting relay.globusonline.org:2223\nDone!\n", b''
```
