### PR TITLE
Port girder/girder#3228

### DIFF
--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -199,17 +199,8 @@ class User(AccessControlledModel):
         elif isinstance(otpToken, six.string_types):
             raise AccessException('The user has not enabled one-time passwords.')
 
-        # This has the same behavior as User.canLogin, but returns more
-        # detailed error messages
-        if user.get('status', 'enabled') == 'disabled':
-            raise AccessException('Account is disabled.', extra='disabled')
-
-        if self.emailVerificationRequired(user):
-            raise AccessException(
-                'Email verification required.', extra='emailVerification')
-
-        if self.adminApprovalRequired(user):
-            raise AccessException('Account approval required.', extra='accountApproval')
+        # Verify the user account is enabled and auth policies are fulfilled
+        self.verifyLogin(user)
 
         return user
 
@@ -404,16 +395,26 @@ class User(AccessControlledModel):
 
         return user
 
+    def verifyLogin(self, user):
+        """
+        Raises an exception if user's account is disabled or one of the auth policies
+        is not fulfilled.
+        """
+        if user.get('status', 'enabled') == 'disabled':
+            raise AccessException('Account is disabled.', extra='disabled')
+        if self.emailVerificationRequired(user):
+            raise AccessException('Email verification required.', extra='emailVerification')
+        if self.adminApprovalRequired(user):
+            raise AccessException('Account approval required.', extra='accountApproval')
+
     def canLogin(self, user):
         """
         Returns True if the user is allowed to login, e.g. email verification
         is not needed and admin approval is not needed.
         """
-        if user.get('status', 'enabled') == 'disabled':
-            return False
-        if self.emailVerificationRequired(user):
-            return False
-        if self.adminApprovalRequired(user):
+        try:
+            self.verifyLogin(user)
+        except AccessException:
             return False
         return True
 

--- a/plugins/oauth/server/rest.py
+++ b/plugins/oauth/server/rest.py
@@ -28,6 +28,7 @@ from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
 from girder.api import access
 from girder.models.setting import Setting
+from girder.models.user import User
 from girder.models.token import Token
 from . import constants, providers
 
@@ -141,6 +142,7 @@ class OAuth(Resource):
             raise cherrypy.HTTPRedirect(redirect)
 
         user = providerObj.getUser(token)
+        User().verifyLogin(user)
 
         event = events.trigger('oauth.auth_callback.after', {
             'provider': provider,


### PR DESCRIPTION
Allows to moderate users registering via OAuth.

### How to test?
1. Use `xarthisius/girder:pr3228` image (or build it yourself)
2. Deploy following https://github.com/whole-tale/girder_wholetale/pull/574
3. As admin, go to https://girder.local.wholetale.org/#settings , set Administrative Policy / Registration policy to "Admin approval required". Click "Save" at the very bottom of the page.
4. In an incognito session, access https://docs.local.wholetale.org and follow OAuth flow.
5. Confirm you get an ugly page with raw json saying:
    ```
    {
        "extra": "accountApproval",
        "message": "Account approval required.",
        "type": "access"
    }
    ```
6. As admin, go to https://girder.local.wholetale.org/#users . Confirm that your regular user (the one from OAuth flow) is annotated with "Account pending approval"
7. Click on the user. From item menu ("`<user icon>` Actions") select approve account.
8. In an incognito session, access https://docs.local.wholetale.org. Docs should be accessible now.