### PR TITLE
Show a custom page for accounts pending approval

### DIFF
--- a/plugins/oauth/server/approval_pending.mako
+++ b/plugins/oauth/server/approval_pending.mako
@@ -1,0 +1,4 @@
+<div style="background-color: #3f3b3b; color: white; padding: 10px;\
+            margin-bottom: 15px; font-family: Arial, sans-serif; font-size: 16px;\
+            font-weight: bold;">${brandName}</div>
+<p>Your account that needs an admin approval. You'll be notified by email about further actions.</p>

--- a/plugins/oauth/server/approval_pending.mako
+++ b/plugins/oauth/server/approval_pending.mako
@@ -1,4 +1,4 @@
 <div style="background-color: #3f3b3b; color: white; padding: 10px;\
             margin-bottom: 15px; font-family: Arial, sans-serif; font-size: 16px;\
             font-weight: bold;">${brandName}</div>
-<p>Your account that needs an admin approval. You'll be notified by email about further actions.</p>
+<p>Use of this service requires administrative approval. Approval is pending and you will be notified via email about any further actions.</p>


### PR DESCRIPTION
### How to test?
1. Apply following changes to deploy-dev:
```
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -61,7 +61,7 @@ services:
         - "traefik.enable=false"
 
   girder:
-    image: wholetale/girder:latest
+    image: wholetale/girder:approval
     networks:
       - traefik-net
       - celery
--- a/setup_girder.py
+++ b/setup_girder.py
@@ -149,6 +149,7 @@ if os.environ.get("DATACAT"):
         {"key": "wholetale.dashboard_link_title", "value": "Tale Dashboard"},
         {"key": "wholetale.catalog_link_title", "value": "Data Catalog"},
         {"key": "wholetale.enable_data_catalog", "value": True},
+        {"key": "core.registration_policy", "value": "approve"},
     ]
 
 r = requests.put(
```
2. Deploy with `DATACAT=1 make dev`
3. Login using your regular oauth account
4. Custom page should display.